### PR TITLE
Add support for bss chip and fast sections.

### DIFF
--- a/elf2hunk.c
+++ b/elf2hunk.c
@@ -875,6 +875,16 @@ int elf2hunk(int file, int hunk_fd, const char *libname, int flags)
 							hh[i]->memflags |= MEMF_KICK;
 						} else if(strcmp(nameext, ".MEMF_FAST") == 0) {
 							hh[i]->memflags |= MEMF_FAST;
+						} else if(strcmp(nameext, ".MEMF_CHIP_BSS") == 0) {
+							free(hh[i]->data);
+							hh[i]->memflags |= MEMF_CHIP;
+							hh[i]->type = HUNK_BSS;
+							hh[i]->data = NULL;
+						} else if(strcmp(nameext, ".MEMF_FAST_BSS") == 0) {
+							free(hh[i]->data);
+							hh[i]->memflags |= MEMF_FAST;
+							hh[i]->type = HUNK_BSS;
+							hh[i]->data = NULL;
 						}
 					}
 				}


### PR DESCRIPTION
Added two new section attributes: MEMF_CHIP_BSS and MEMF_FAST_BSS.

With these you can specify bss sections for the specified memory types.

This is intended to resolve this issue:
https://github.com/BartmanAbyss/vscode-amiga-debug/issues/75